### PR TITLE
Bug Fixes

### DIFF
--- a/app/views/exporter-v11/_routes.js
+++ b/app/views/exporter-v11/_routes.js
@@ -876,7 +876,7 @@ router.post('/waste-identification-codes', function(req, res) {
 })
 
 // countries-states-concerned
-router.post('/countries-states-concerne-new', function(req, res) {
+router.post('/countries-states-concerned-new', function(req, res) {
     req.session.data['countries-states-concerned-status'] = "Completed";
 
     if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {

--- a/app/views/exporter-v11/index.html
+++ b/app/views/exporter-v11/index.html
@@ -34,12 +34,20 @@
         <li>download and print an Annex VII form to include with your waste shipment (this will be created using the information that you enter)</li>
       </ul>
 
-      <form method="post" novalidate>
+      <!-- ORIGINAL BUTTON CODE - GOES NOWHERE?
+        <form method="post" novalidate>
         {{ govukButton({
           text: "Start now",
           isStartButton: true
         }) }}
-      </form>
+      </form> 
+    -->
+
+    <a href="dashboard.html" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+      Start now
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg></a>
 
     </div>
   </div>

--- a/app/views/exporter-v11/view-submitted-export.html
+++ b/app/views/exporter-v11/view-submitted-export.html
@@ -241,7 +241,7 @@
         <div class="app-step-nav-related">
           <h2 class="app-step-nav-related__heading">
             <span class="app-step-nav-related__pretitle">Actions</span>
-            <p class="govuk-body"><a href="../public/pdfs/hdj2123f-annex-vii.pdf" class="govuk-link">Download Annex VIII form</a>
+            <p class="govuk-body"><a href="../public/pdfs/hdj2123f-annex-vii.pdf" class="govuk-link">Download Annex VII form</a>
               (PDF, 78 KB, 1 page).</p>
               <p class="govuk-body"><a href="submitted-cancel-export" class="govuk-link">Cancel export</a></p>
 


### PR DESCRIPTION
- typo fixed on 'countries-states-concerned-new' in routes.js which was preventing the No option being marked as complete (transit countries)
- new start button on the temporary start page to link it to the rest of the prototype
- typo on the view submitted export screen from Annex 8 to Annex 7 (numerals)