### PR TITLE
Version number in Phase banner + new global layout file 

### DIFF
--- a/app/views/exporter-v11/accessibility-statement.html
+++ b/app/views/exporter-v11/accessibility-statement.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Accessibility statement - Export green list waste

--- a/app/views/exporter-v11/accessible-autocomplete.html
+++ b/app/views/exporter-v11/accessible-autocomplete.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What is the recovery or disposal code? - Export green list waste

--- a/app/views/exporter-v11/api-information.html
+++ b/app/views/exporter-v11/api-information.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   I want to bulk transfer data - Export green list waste

--- a/app/views/exporter-v11/bulk-uploading.html
+++ b/app/views/exporter-v11/bulk-uploading.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Uploading your spreadsheet - Export green list waste

--- a/app/views/exporter-v11/bulk.html
+++ b/app/views/exporter-v11/bulk.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Upload a spreadsheet of waste exports - Export green list waste

--- a/app/views/exporter-v11/cancel-export.html
+++ b/app/views/exporter-v11/cancel-export.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Are you sure you want to cancel this export?

--- a/app/views/exporter-v11/carrier-add-1.html
+++ b/app/views/exporter-v11/carrier-add-1.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Who is the first waste carrier?

--- a/app/views/exporter-v11/carrier-add-2.html
+++ b/app/views/exporter-v11/carrier-add-2.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Who are the waste carriers? - Export green list waste

--- a/app/views/exporter-v11/carrier-add-3.html
+++ b/app/views/exporter-v11/carrier-add-3.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Enter the additional waste carrier’s details

--- a/app/views/exporter-v11/carrier-check.html
+++ b/app/views/exporter-v11/carrier-check.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   You have added 1 additional waste carrier

--- a/app/views/exporter-v11/carrier-collect-address-manual.html
+++ b/app/views/exporter-v11/carrier-collect-address-manual.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Where will the first carrier collect the waste from?

--- a/app/views/exporter-v11/carrier-collect-address.html
+++ b/app/views/exporter-v11/carrier-collect-address.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Where will the first carrier collect the waste from?

--- a/app/views/exporter-v11/carrier-collect-postcode.html
+++ b/app/views/exporter-v11/carrier-collect-postcode.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Where will the first carrier collect the waste from?

--- a/app/views/exporter-v11/carrier-delete.html
+++ b/app/views/exporter-v11/carrier-delete.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Are you sure you want to remove this additional waste carrier?

--- a/app/views/exporter-v11/carrier-transport-1.html
+++ b/app/views/exporter-v11/carrier-transport-1.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   How will the first waste carrier transport the waste?

--- a/app/views/exporter-v11/carrier-transport-2.html
+++ b/app/views/exporter-v11/carrier-transport-2.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   How will the additional waste carrier transport the waste?

--- a/app/views/exporter-v11/carrier-transport-3.html
+++ b/app/views/exporter-v11/carrier-transport-3.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   How will the additional waste carrier transport the waste?

--- a/app/views/exporter-v11/carriers.html
+++ b/app/views/exporter-v11/carriers.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Do you need to add another waste carrier?

--- a/app/views/exporter-v11/check-your-answers.html
+++ b/app/views/exporter-v11/check-your-answers.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Check this export

--- a/app/views/exporter-v11/code-add-another.html
+++ b/app/views/exporter-v11/code-add-another.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   You have added 1 EC list of waste

--- a/app/views/exporter-v11/confirmation.html
+++ b/app/views/exporter-v11/confirmation.html
@@ -1,17 +1,21 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Export submitted
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is not a live service.'
-  }) }}
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      Prototype
+    </strong>
+    <span class="govuk-phase-banner__text">
+      Version 11 - This is not a live service.
+    </span>
+  </p>
+  </div>
 {% endblock %}
 
 {% block content %}

--- a/app/views/exporter-v11/container-number.html
+++ b/app/views/exporter-v11/container-number.html
@@ -1,4 +1,4 @@
-  {% extends "../layouts/layout-exporter-v5.html" %}
+  {% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Do you know the container number? - Export green list waste

--- a/app/views/exporter-v11/cookies.html
+++ b/app/views/exporter-v11/cookies.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Cookies - Export green list waste

--- a/app/views/exporter-v11/countries-add-2.html
+++ b/app/views/exporter-v11/countries-add-2.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Select another country

--- a/app/views/exporter-v11/countries-add-another.html
+++ b/app/views/exporter-v11/countries-add-another.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   You have added 1 transit country

--- a/app/views/exporter-v11/countries-states-concerned-new.html
+++ b/app/views/exporter-v11/countries-states-concerned-new.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Are there any other countries the waste will travel through?

--- a/app/views/exporter-v11/countries-states-concerned_old.html
+++ b/app/views/exporter-v11/countries-states-concerned_old.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Are there any other countries the waste will travel through?

--- a/app/views/exporter-v11/create-template-success.html
+++ b/app/views/exporter-v11/create-template-success.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Template created - Export green list waste

--- a/app/views/exporter-v11/dashboard.html
+++ b/app/views/exporter-v11/dashboard.html
@@ -1,17 +1,21 @@
 
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Home - Export green list waste
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is not a live service.'
-  }) }}
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      Prototype
+    </strong>
+    <span class="govuk-phase-banner__text">
+      Version 11 - This is not a live service.
+    </span>
+  </p>
+</div>
 
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">

--- a/app/views/exporter-v11/date-of-shipment.html
+++ b/app/views/exporter-v11/date-of-shipment.html
@@ -21,7 +21,7 @@
               </h1>
             </legend>
 
-            <!---------- DYNAMIC DATE +3 Days ---------->
+<!--             ---------- DYNAMIC DATE +3 Days ----------
 
             <script>
               const event = new Date();
@@ -32,9 +32,8 @@
 
             <!---------- END DYNAMIC DATE ---------->
 
-            <!--        <p class="govuk-body">
-                      This must be on 11 July 2022 or after.
-                      </p> -->
+            <p class="govuk-body">
+                      The collection date must be at least 3 working days from today</p>
 
 
             <div class="govuk-radios" data-module="govuk-radios">

--- a/app/views/exporter-v11/date-of-shipment.html
+++ b/app/views/exporter-v11/date-of-shipment.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Do you know when the waste will be collected?

--- a/app/views/exporter-v11/declaration.html
+++ b/app/views/exporter-v11/declaration.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Are you sure you want to submit this export?

--- a/app/views/exporter-v11/delete-confirmation.html
+++ b/app/views/exporter-v11/delete-confirmation.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   {% if data['manual-bulk'] == 'bulk' %}

--- a/app/views/exporter-v11/delete-draft-export.html
+++ b/app/views/exporter-v11/delete-draft-export.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Are you sure you want to delete this draft export?

--- a/app/views/exporter-v11/delete-template.html
+++ b/app/views/exporter-v11/delete-template.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Delete favourite - Export green list waste

--- a/app/views/exporter-v11/draft-cancel-confirmation.html
+++ b/app/views/exporter-v11/draft-cancel-confirmation.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Submission has been cancelled - Export green list waste

--- a/app/views/exporter-v11/draft-cancel.html
+++ b/app/views/exporter-v11/draft-cancel.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Are you sure you want to cancel this submission? - Export green list waste

--- a/app/views/exporter-v11/draft-export.html
+++ b/app/views/exporter-v11/draft-export.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Check your answers - Export green list waste

--- a/app/views/exporter-v11/draft-exports.html
+++ b/app/views/exporter-v11/draft-exports.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Draft exports

--- a/app/views/exporter-v11/draft-prenotify.html
+++ b/app/views/exporter-v11/draft-prenotify.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Submission created 2 June 2021 - Export green list waste

--- a/app/views/exporter-v11/ec-code-2.html
+++ b/app/views/exporter-v11/ec-code-2.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Enter an EWC code

--- a/app/views/exporter-v11/ec-code.html
+++ b/app/views/exporter-v11/ec-code.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Do you have any EC list of wastes?

--- a/app/views/exporter-v11/enter-estimate-waste.html
+++ b/app/views/exporter-v11/enter-estimate-waste.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Enter an estimate for the quantity of waste - Export green list waste

--- a/app/views/exporter-v11/enter-waste.html
+++ b/app/views/exporter-v11/enter-waste.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Enter the quantity of waste - Export green list waste

--- a/app/views/exporter-v11/exporter-address-manual.html
+++ b/app/views/exporter-v11/exporter-address-manual.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What's the exporter's address?

--- a/app/views/exporter-v11/exporter-address.html
+++ b/app/views/exporter-v11/exporter-address.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What's the exporter's address?

--- a/app/views/exporter-v11/exporter-postcode.html
+++ b/app/views/exporter-v11/exporter-postcode.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What's the exporter's address?

--- a/app/views/exporter-v11/final-recovery-disposal.html
+++ b/app/views/exporter-v11/final-recovery-disposal.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What is the final recovery or disposal code? - Export green list waste

--- a/app/views/exporter-v11/importer-consignee.html
+++ b/app/views/exporter-v11/importer-consignee.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Who’s the importer?

--- a/app/views/exporter-v11/index.html
+++ b/app/views/exporter-v11/index.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Submit information on a shipment of green list waste - Export green list waste

--- a/app/views/exporter-v11/interim-site.html
+++ b/app/views/exporter-v11/interim-site.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What is the address of the interim site? - Export green list waste

--- a/app/views/exporter-v11/lab-check-your-answers.html
+++ b/app/views/exporter-v11/lab-check-your-answers.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Check this export

--- a/app/views/exporter-v11/lab-code-add-another.html
+++ b/app/views/exporter-v11/lab-code-add-another.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   You have added 1 EC list of waste

--- a/app/views/exporter-v11/lab-ec-code-2.html
+++ b/app/views/exporter-v11/lab-ec-code-2.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Enter an EWC code

--- a/app/views/exporter-v11/lab-enter-waste.html
+++ b/app/views/exporter-v11/lab-enter-waste.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Enter the quantity of waste - Export green list waste

--- a/app/views/exporter-v11/lab-prenotify-2.html
+++ b/app/views/exporter-v11/lab-prenotify-2.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Export green list waste

--- a/app/views/exporter-v11/lab-prenotify-3.html
+++ b/app/views/exporter-v11/lab-prenotify-3.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Export green list waste

--- a/app/views/exporter-v11/lab-prenotify.html
+++ b/app/views/exporter-v11/lab-prenotify.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Export green list waste

--- a/app/views/exporter-v11/lab-quantity.html
+++ b/app/views/exporter-v11/lab-quantity.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Do you know the quantity of waste? - Export green list waste

--- a/app/views/exporter-v11/lab-recovery-facility-laboratory.html
+++ b/app/views/exporter-v11/lab-recovery-facility-laboratory.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Recovery facility details

--- a/app/views/exporter-v11/lab-recovery-operation.html
+++ b/app/views/exporter-v11/lab-recovery-operation.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What is the recovery code?

--- a/app/views/exporter-v11/lab-waste-codes-and-description.html
+++ b/app/views/exporter-v11/lab-waste-codes-and-description.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 What’s the waste code?

--- a/app/views/exporter-v11/manual-bulk-api.html
+++ b/app/views/exporter-v11/manual-bulk-api.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   How do you want to enter the information? - Export green list waste

--- a/app/views/exporter-v11/national-code.html
+++ b/app/views/exporter-v11/national-code.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Do you have a national code?

--- a/app/views/exporter-v11/point-of-exit.html
+++ b/app/views/exporter-v11/point-of-exit.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Do you know the location at which the waste will leave the United Kingdom?

--- a/app/views/exporter-v11/prenotification-templates.html
+++ b/app/views/exporter-v11/prenotification-templates.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Your saved templates - Export green list waste

--- a/app/views/exporter-v11/prenotify.html
+++ b/app/views/exporter-v11/prenotify.html
@@ -1,16 +1,20 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Export green list waste
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is not a live service.'
-  }) }}
+  <div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      Prototype
+    </strong>
+    <span class="govuk-phase-banner__text">
+      Version 11 - This is not a live service.
+    </span>
+  </p>
+  </div>
 
   <!---------- Breadcrumbs ---------->
 
@@ -57,7 +61,8 @@
 
       <ol class="app-task-list">
 
-        <!---------- SECTION 1 ---------->
+        <!------------------ SECTION 1 ------------------------>
+
         {# ABOUT THE WASTE #}
         <li>
           <h2 class="app-task-list__section">
@@ -102,7 +107,8 @@
           </ul>
         </li>
 
-        <!---------- SECTION 2 ---------->
+        <!----------------- SECTION 2 ---------------------->
+
         {# EXPORTER AND IMPORTER DETAILS #}
         <li>
           <h2 class="app-task-list__section">
@@ -142,7 +148,8 @@
           </ul>
         </li>
 
-        <!---------- SECTION 3 ---------->
+        <!------------------- SECTION 3 ------------------------->
+
         {# JOURNEY OF WASTE #}
         <li>
           <h2 class="app-task-list__section">
@@ -227,7 +234,8 @@
           </ul>
         </li>
 
-        <!---------- SECTION 4 ---------->
+        <!--------------------- SECTION 4 ----------------------------->
+
         {# RECOVERY OR DISPOSAL OF WASTE #}
 
         <!---------- Recovery or laboratory ---------->
@@ -254,6 +262,7 @@
                 </a>
               </span>
 
+              <!-- Turns the link on and off -->
               {% if data['usual-description-of-the-waste-status'] == null or data['usual-description-of-the-waste-status'] == 'Not started' and
               data['quantity-status'] == null or data['quantity-status'] == 'Not started' %}
               <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="submit-export">Cannot start yet</strong>
@@ -263,7 +272,6 @@
 
               {% elseif data['recovery-facility-or-laboratory-status'] == 'Completed' %}
                 <strong class="govuk-tag app-task-list__tag" id="recovery-facility-or-laboratory-status">Completed</strong>
-
 
               {% endif %}
 

--- a/app/views/exporter-v11/preparation.html
+++ b/app/views/exporter-v11/preparation.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Preparation - Export green list waste

--- a/app/views/exporter-v11/privacy-notice.html
+++ b/app/views/exporter-v11/privacy-notice.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Privacy notice - Export green list waste

--- a/app/views/exporter-v11/quantity-actual-metres.html
+++ b/app/views/exporter-v11/quantity-actual-metres.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Enter quantity of waste

--- a/app/views/exporter-v11/quantity-estimate-metres.html
+++ b/app/views/exporter-v11/quantity-estimate-metres.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Enter an estimate for quantity of waste

--- a/app/views/exporter-v11/quantity.html
+++ b/app/views/exporter-v11/quantity.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Do you know the quantity of waste?

--- a/app/views/exporter-v11/recovery-facility-laboratory.html
+++ b/app/views/exporter-v11/recovery-facility-laboratory.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Recovery facility details

--- a/app/views/exporter-v11/recovery-operation.html
+++ b/app/views/exporter-v11/recovery-operation.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What is the recovery code?

--- a/app/views/exporter-v11/save-as-template.html
+++ b/app/views/exporter-v11/save-as-template.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Save a template - Export green list waste

--- a/app/views/exporter-v11/search-sort-filter-variant-a.html
+++ b/app/views/exporter-v11/search-sort-filter-variant-a.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   View all submitted exports  - Export green list waste

--- a/app/views/exporter-v11/search-sort-filter-variant-b.html
+++ b/app/views/exporter-v11/search-sort-filter-variant-b.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   View all submitted exports  - Export green list waste

--- a/app/views/exporter-v11/service-start.html
+++ b/app/views/exporter-v11/service-start.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Export green list waste

--- a/app/views/exporter-v11/submitted-817435283-alert.html
+++ b/app/views/exporter-v11/submitted-817435283-alert.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Check your answers - Export green list waste

--- a/app/views/exporter-v11/submitted-817435283-update-quantity.html
+++ b/app/views/exporter-v11/submitted-817435283-update-quantity.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What is the quantity of waste? - Export green list waste

--- a/app/views/exporter-v11/submitted-817435283-update-shipment.html
+++ b/app/views/exporter-v11/submitted-817435283-update-shipment.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   When will the waste be picked up? - Export green list waste

--- a/app/views/exporter-v11/submitted-817435283-update.html
+++ b/app/views/exporter-v11/submitted-817435283-update.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Check your answers - Export green list waste

--- a/app/views/exporter-v11/submitted-cancel-export.html
+++ b/app/views/exporter-v11/submitted-cancel-export.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Why do you want to cancel this export?

--- a/app/views/exporter-v11/submitted-exports.html
+++ b/app/views/exporter-v11/submitted-exports.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   View submitted exports

--- a/app/views/exporter-v11/submitted-prenotifications-split-view-example.html
+++ b/app/views/exporter-v11/submitted-prenotifications-split-view-example.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   View all submitted exports  - Export green list waste

--- a/app/views/exporter-v11/submitted-prenotifications.html
+++ b/app/views/exporter-v11/submitted-prenotifications.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   View all submitted exports  - Export green list waste

--- a/app/views/exporter-v11/template-confirmation.html
+++ b/app/views/exporter-v11/template-confirmation.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Submission completed - Export green list waste

--- a/app/views/exporter-v11/template-edit-name.html
+++ b/app/views/exporter-v11/template-edit-name.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Update template name - Export green list waste

--- a/app/views/exporter-v11/template-euromovement-edit.html
+++ b/app/views/exporter-v11/template-euromovement-edit.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Euromovement paper waste movement - Export green list waste

--- a/app/views/exporter-v11/template-euromovement-selected.html
+++ b/app/views/exporter-v11/template-euromovement-selected.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Euromovement paper waste movement - Export green list waste

--- a/app/views/exporter-v11/template-euromovement.html
+++ b/app/views/exporter-v11/template-euromovement.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Euromovement paper waste movement - Export green list waste

--- a/app/views/exporter-v11/template-fabirc-society-selected.html
+++ b/app/views/exporter-v11/template-fabirc-society-selected.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Euromovement paper waste movement - Export green list waste

--- a/app/views/exporter-v11/transaction-id.html
+++ b/app/views/exporter-v11/transaction-id.html
@@ -1,4 +1,4 @@
-  {% extends "../layouts/layout-exporter-v5.html" %}
+  {% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Your transaction number - Export green list waste

--- a/app/views/exporter-v11/unique-ref.html
+++ b/app/views/exporter-v11/unique-ref.html
@@ -1,18 +1,22 @@
 
 
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Do you want to add your own reference number to this export?
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is not a live service.'
-  }) }}
+  <div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      Prototype
+    </strong>
+    <span class="govuk-phase-banner__text">
+      Version 11 - This is not a live service.
+    </span>
+  </p>
+  </div>
 
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">

--- a/app/views/exporter-v11/update-carrier-transport.html
+++ b/app/views/exporter-v11/update-carrier-transport.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Update how the first waste carrier will transport the waste with actual details

--- a/app/views/exporter-v11/update-carrier.html
+++ b/app/views/exporter-v11/update-carrier.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Update the first waste carrier with actual details

--- a/app/views/exporter-v11/update-check-your-answers-2.html
+++ b/app/views/exporter-v11/update-check-your-answers-2.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Update export with actual details

--- a/app/views/exporter-v11/update-check-your-answers-3.html
+++ b/app/views/exporter-v11/update-check-your-answers-3.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Update export with actual details

--- a/app/views/exporter-v11/update-check-your-answers.html
+++ b/app/views/exporter-v11/update-check-your-answers.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Update export with actual details

--- a/app/views/exporter-v11/update-confirmation.html
+++ b/app/views/exporter-v11/update-confirmation.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Export successfully updated

--- a/app/views/exporter-v11/update-date.html
+++ b/app/views/exporter-v11/update-date.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Update the collection date with actual details

--- a/app/views/exporter-v11/update-delete-export.html
+++ b/app/views/exporter-v11/update-delete-export.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Why do you want to cancel this export?

--- a/app/views/exporter-v11/update-prenotifications.html
+++ b/app/views/exporter-v11/update-prenotifications.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Update an export with actual details

--- a/app/views/exporter-v11/update-quantity-kilograms.html
+++ b/app/views/exporter-v11/update-quantity-kilograms.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Update the quantity of waste with actual details

--- a/app/views/exporter-v11/update-quantity-link.html
+++ b/app/views/exporter-v11/update-quantity-link.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Update the quantity of waste with actual details

--- a/app/views/exporter-v11/update-quantity-metres-link.html
+++ b/app/views/exporter-v11/update-quantity-metres-link.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Update the quantity of waste with actual details

--- a/app/views/exporter-v11/update-quantity-metres.html
+++ b/app/views/exporter-v11/update-quantity-metres.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Update the quantity of waste with actual details

--- a/app/views/exporter-v11/update-quantity.html
+++ b/app/views/exporter-v11/update-quantity.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 Update the quantity of waste with actual details

--- a/app/views/exporter-v11/usual-description.html
+++ b/app/views/exporter-v11/usual-description.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Provide a description of the weaste - Export green list waste

--- a/app/views/exporter-v11/view-375518473.html
+++ b/app/views/exporter-v11/view-375518473.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Received Annex VII forms - Export green list waste

--- a/app/views/exporter-v11/view-409413376.html
+++ b/app/views/exporter-v11/view-409413376.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Unique ID 409413376 - Export green list waste

--- a/app/views/exporter-v11/view-817435283.html
+++ b/app/views/exporter-v11/view-817435283.html
@@ -1,5 +1,5 @@
 
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Unique ID 817435283 - Export green list waste

--- a/app/views/exporter-v11/view-828528178.html
+++ b/app/views/exporter-v11/view-828528178.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Check your answers - Export green list waste

--- a/app/views/exporter-v11/view-all-cancel-confirmation.html
+++ b/app/views/exporter-v11/view-all-cancel-confirmation.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Submission has been cancelled - Export green list waste

--- a/app/views/exporter-v11/view-all-cancel.html
+++ b/app/views/exporter-v11/view-all-cancel.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Are you sure you want to cancel this submission? - Export green list waste

--- a/app/views/exporter-v11/view-submitted-export.html
+++ b/app/views/exporter-v11/view-submitted-export.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   View export

--- a/app/views/exporter-v11/waste-codes-and-description.html
+++ b/app/views/exporter-v11/waste-codes-and-description.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
 What’s the waste code?

--- a/app/views/exporter-v11/waste-description.html
+++ b/app/views/exporter-v11/waste-description.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Describe the waste

--- a/app/views/exporter-v11/waste-generator.html
+++ b/app/views/exporter-v11/waste-generator.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Waste collection details

--- a/app/views/exporter-v11/waste-identification-codes.html
+++ b/app/views/exporter-v11/waste-identification-codes.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   What are the relevant waste identification codes? - Export green list waste

--- a/app/views/exporter-v11/waste-treated.html
+++ b/app/views/exporter-v11/waste-treated.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v5.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Where will the waste be treated?

--- a/app/views/exporter-v11/who-arranged-shipment-details.html
+++ b/app/views/exporter-v11/who-arranged-shipment-details.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/layout-exporter-v11.html" %}
+{% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
   Exporter's details

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -42,7 +42,7 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">
                 <a href="exporter-v11/dashboard">V11</a>
-              <td class="govuk-table__cell">26 to 29</td>
+              <td class="govuk-table__cell">26 to 30</td>
               <td class="govuk-table__cell">
                 <ul class="govuk-list govuk-list--bullet">
                   <li>Iterated hint text for reference number, national code, exporter details and exit location</li>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -9,7 +9,7 @@
     tag: {
       text: "prototype"
     },
-    html: 'This is not a live service.'
+    html: 'Version 11 - This is not a live service.'
   }) }}
   {% endblock %}
 

--- a/app/views/layouts/layout-exporter-current.html
+++ b/app/views/layouts/layout-exporter-current.html
@@ -1,3 +1,6 @@
+{#----- This file needs to be cloned for every new version of the prototype and version references updated below! -----#}
+{#----- The previous version can then be used as a backup - this was started at V11. -----#}
+
 {#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
 {%- set assetPath = '/govuk/assets' -%}
 
@@ -77,6 +80,7 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{# ----- Update the version number in the Phase banner here ------ #}
 {% block beforeContent %}
   <div class="govuk-phase-banner">
     <p class="govuk-phase-banner__content">
@@ -94,6 +98,7 @@
   }) }}
 {% endblock %}
 
+{# ----- Update links to version pages here ------ #}
 {% if useAutoStoreData %}
   {% block footer %}
     <footer class="govuk-footer " role="contentinfo">

--- a/app/views/previous-prototypes.html
+++ b/app/views/previous-prototypes.html
@@ -20,9 +20,9 @@
 
     <form method="post">
 
-        <p>Contact <a href="mailto:emma.hidalgolaw@defra.gov.uk">Emma Hidalgo-Law</a> (Interaction Designer)
-          or <a href="mailto:priya.nahar@defra.gov.uk">Priya Nahar</a> (Content Designer) if you have any questions.</p>
-        <br><br>
+      <p>Contact <a href="mailto:phil.isaac@defra.gov.uk">Phil Isaac</a> (Interaction Designer)
+        or <a href="mailto:melissa.massey@defra.gov.uk">Melissa Massey</a> (Content Designer) if you have any questions.</p>
+      <br><br>
 
         <h1 class="govuk-heading-l">Previous prototypes</h1>
 


### PR DESCRIPTION
- all screens now reference a global layout file 'layout-exporter-current' (update this file in future to avoid updating the link for version specific file on every exporter screen)
- version number added to the phase banner for visibility in screenshots.

