### PR TITLE
Update to link behaviour on Prenotify

### DIFF
--- a/app/views/exporter-v11/_routes.js
+++ b/app/views/exporter-v11/_routes.js
@@ -812,7 +812,8 @@ router.post('/waste-codes-and-description', function(req, res) {
 
 
 router.post('/national-code', function(req, res) {
-    req.session.data['usual-description-of-the-waste-status'] = "Completed";
+    //req.session.data['usual-description-of-the-waste-status'] = "Completed";
+    req.session.data['usual-description-of-the-waste-status'] = "In Progress";
 
     if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
         res.redirect('check-your-answers');
@@ -853,7 +854,8 @@ router.post('/waste-description', function(req, res) {
     }
 })
 
-// usual-description
+/* ** NO LONGER IN USE v11 ***
+// usual-description 
 router.post('/usual-description', function(req, res) {
     req.session.data['usual-description-of-the-waste-status'] = "Completed";
 
@@ -862,8 +864,10 @@ router.post('/usual-description', function(req, res) {
     } else {
         res.redirect('prenotify');
     }
-})
+}) 
+*/
 
+/* ** NO LONGER IN USE v11 ***
 // waste-identification-codes
 router.post('/waste-identification-codes', function(req, res) {
     req.session.data['waste-identification-codes-status'] = "Completed";
@@ -874,6 +878,7 @@ router.post('/waste-identification-codes', function(req, res) {
         res.redirect('prenotify');
     }
 })
+*/
 
 // countries-states-concerned
 /* router.post('/countries-states-concerned-new', function(req, res) {

--- a/app/views/exporter-v11/prenotify.html
+++ b/app/views/exporter-v11/prenotify.html
@@ -88,11 +88,33 @@
             <!---------- Quantity of waste ---------->
 
             <li class="app-task-list__item">
+
+              <!-- Turns the link on and off -->
               <span class="app-task-list__task-name">
+                
+                  {% if data ['code'] == "basel" or data ['code'] == "oecd" or data ['code'] == "annex-a" or data ['code'] == "annex-b" %}
+                  <a href="quantity" aria-describedby="eligibility-status">
+                  Quantity of waste
+                  {% elseif data ['code'] == "not-applicable" %}
+                  <span class="app-task-list__task-name">
+                    Quantity of waste
+                  </span>
+                  {% else %}
+                  <span class="app-task-list__task-name">
+                    Quantity of waste
+                  </span>
+                  {% endif %}
+                </a>
+              </span>
+
+              <!-- 
+                <span class="app-task-list__task-name">
                 <a href="quantity" aria-describedby="read-declaration-status">
                   Quantity of waste
                 </a>
               </span>
+             -->
+
               {% if data['usual-description-of-the-waste-status'] == null or data['usual-description-of-the-waste-status'] == 'Not started' and
               data['quantity-status'] == null or data['quantity-status'] == 'Not started' %}
               <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="submit-export">Cannot start yet</strong>
@@ -248,6 +270,7 @@
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
 
+                <!-- Turns the link on and off -->
                   {% if data ['code'] == "not-applicable" %}
                   <a href="recovery-facility-laboratory" aria-describedby="eligibility-status">
                   Laboratory details
@@ -262,7 +285,7 @@
                 </a>
               </span>
 
-              <!-- Turns the link on and off -->
+              <!-- Sets the tag status -->
               {% if data['usual-description-of-the-waste-status'] == null or data['usual-description-of-the-waste-status'] == 'Not started' and
               data['quantity-status'] == null or data['quantity-status'] == 'Not started' %}
               <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="submit-export">Cannot start yet</strong>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -9,7 +9,7 @@
     tag: {
       text: "prototype"
     },
-    html: 'Version 11 - This is not a live service.'
+    html: 'This is not a live service.'
   }) }}
   {% endblock %}
 
@@ -50,6 +50,7 @@
                   <li>Reduced waste description Textarea size and implemented 100 character limit </li>
                   <li>Iterated waste description help text (removed reference to EN codes) </li>
                   <li>Changed transit countries (section 3) from a free text entry to 'add another' pattern </li>
+                  <li>Quantity of Waste link is now disabled until a Waste Code has been selected. Usability now matches the 'Cannot start yet' tag. </li>
                 </ul>
                 </td>
             </tr>


### PR DESCRIPTION
- updated the link for Quantity of Waste to match the 'Cannot start yet' tag, so it is disabled until a Waste Code is selected.
- updates noted on the Index page.