### PR TITLE
Finish building the reject path for imports - bug fixes

### DIFF
--- a/app/views/exporter-v13/_routes.js
+++ b/app/views/exporter-v13/_routes.js
@@ -2244,11 +2244,16 @@ router.post('/imports-date-of-shipment', function(req, res) {
 // Reject already told us
 router.post('/imports-reject-told-us', function(req, res) {
     if (req.session.data['told-us'] == 'yes') {
-        res.redirect('imports-reject-submitted');
+        res.redirect('imports-reject-search-submitted');
     } else if (req.session.data['told-us'] == 'no') {
         res.redirect('imports-reject-unique-ref');
     }
 })
+
+// imports-reject-search-submitted
+router.post('/imports-reject-search-submitted', function(req, res) {
+    res.redirect('imports-reject-search-results-1');
+ })
 
 // imports-reject-unique-ref
 router.post('/imports-reject-unique-ref', function(req, res) {

--- a/app/views/exporter-v13/delete-confirmation.html
+++ b/app/views/exporter-v13/delete-confirmation.html
@@ -16,7 +16,7 @@
       Prototype
     </strong>
     <span class="govuk-phase-banner__text">
-      Version 12 - This is not a live service.
+      Version 13 - This is not a live service.
     </span>
   </p>
 </div>

--- a/app/views/exporter-v13/delete-template.html
+++ b/app/views/exporter-v13/delete-template.html
@@ -11,7 +11,7 @@
       Prototype
     </strong>
     <span class="govuk-phase-banner__text">
-      Version 12 - This is not a live service.
+      Version 13 - This is not a live service.
     </span>
   </p>
 </div>
@@ -54,8 +54,8 @@
       </div>
 
         <div class="govuk-button-group">
-          <button class="govuk-button" data-module="govuk-button">
-            Continue
+          <button class="govuk-button govuk-button--warning" data-module="govuk-button">
+            Delete
           </button>
         </div>
         <a class="govuk-link" href="javascript:history.go(-1)">Cancel and return to template list</a>

--- a/app/views/exporter-v13/ec-code.html
+++ b/app/views/exporter-v13/ec-code.html
@@ -21,7 +21,7 @@ Do you have any EC list of wastes?
                     </h1>
                   </legend>
                   <div id="contact-hint" class="govuk-hint">
-                    An EWC code (European Waste Catalogue code) is also known as an EC list of waste.
+                    An EWC code (European Waste Catalogue code) is also known as an EC list of waste code. You must include all 6 digits.
                   </div>
                   <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">

--- a/app/views/exporter-v13/imports-ec-code.html
+++ b/app/views/exporter-v13/imports-ec-code.html
@@ -21,7 +21,7 @@ Do you have any EC list of wastes?
                     </h1>
                   </legend>
                   <div id="contact-hint" class="govuk-hint">
-                    An EWC code (European Waste Catalogue code) is also known as an EC list of waste.
+                    An EWC code (European Waste Catalogue code) is also known as an EC list of waste code. You must include all 6 digits.
                   </div>
                   <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">

--- a/app/views/exporter-v13/imports-point-of-exit.html
+++ b/app/views/exporter-v13/imports-point-of-exit.html
@@ -20,7 +20,7 @@ Do you know the location at which the waste will leave the United Kingdom?
                     </h1>
                   </legend>
 
-                  <p class="govuk-body">For example, a town, port or terminal.</p>
+                  <p class="govuk-body">For example, the nearest town, port or terminal.</p>
 
                   <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">

--- a/app/views/exporter-v13/imports-prenotify.html
+++ b/app/views/exporter-v13/imports-prenotify.html
@@ -325,7 +325,7 @@
 
       </ol>
 
-      <h2 class="govuk-heading-m">Final check</h2>
+      
 
       {% if data['imports-usual-description-of-the-waste-status'] == "Completed" and
       data['imports-quantity-status'] == "Completed" and
@@ -339,6 +339,8 @@
       data['imports-recovery-operation-status'] == "Completed" %}
 
       <form class="form" method="post"></form>
+
+      <h2 class="govuk-heading-m">Final check</h2>
       <!-- <form action="imports-check-your-answers" method="post" novalidate> -->
 
        <!--  <input type="hidden" name="answers-checked" value="true"> -->

--- a/app/views/exporter-v13/imports-reject-check-your-answers.html
+++ b/app/views/exporter-v13/imports-reject-check-your-answers.html
@@ -521,38 +521,54 @@
           </dd> 
         </div>
 
-          <!---------- Reason for rejection ---------->
+        <!---------- Reason for rejection ---------->
 
-          <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Reason for rejection
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <p class="govuk-body">Waste is contaminated</p>
-                <p class="govuk-body">The waste contains materials which cannot be removed and prevents processing.</p>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="#">
-                  Change<span class="govuk-visually-hidden">recovery name</span>
-                </a>
-              </dd>
-            </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Reason for rejection
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body">Waste is contaminated</p>
+            <p class="govuk-body">The waste contains materials which cannot be removed and prevents processing.</p>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+              Change<span class="govuk-visually-hidden">reject reason</span>
+            </a>
+          </dd>
+        </div>
 
-          <!---------- How much rejected ---------->
+        <!---------- How much rejected ---------->
 
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
             Rejection amount
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <p class="govuk-body">All of the waste import</p>
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="#">
-                Change<span class="govuk-visually-hidden">recovery date</span>
-              </a>
-            </dd>
-          </div>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body">All of the waste import</p>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+              Change<span class="govuk-visually-hidden">rejection amount</span>
+            </a>
+          </dd>
+        </div>
+
+        <!---------- What to do next ---------->
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Rejection next steps
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body">Send it back to the exporter</p>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="#">
+              Change<span class="govuk-visually-hidden">reject next steps</span>
+            </a>
+          </dd>
+        </div>
 
         </dl>
         <br>
@@ -560,15 +576,14 @@
         <!--------- DECLARATION ------------------->
 
         <h2 class="govuk-heading-m">
-          Now confirm the import details
+          Confirm the rejected import details
         </h2>
 
-        <p class="govuk-body">By submitting this import, you confirm that:</p>
+        <p class="govuk-body">By submitting this information, you confirm that:</p>
 
         <ul class="govuk-body">
           <li>all the information you've provided is complete and correct to the best of your knowledge</li>
-          <li>there is an effective written contract with the overseas exporter arranging the shipment</li>
-          <li>you've taken legal responsibility of the waste</li>
+          <li>you want to reject this waste import</li>
         </ul>
 
         <div class="govuk-!-padding-bottom-4"></div>
@@ -584,7 +599,7 @@
           Confirm and submit
         </button> -->
         
-        <a href="imports-reject-whatnext-options.html"><button class="govuk-button" data-module="govuk-button">
+        <a href="imports-reject-confirmation.html"><button class="govuk-button" data-module="govuk-button">
           Confirm and continue
         </button></a>
 

--- a/app/views/exporter-v13/imports-reject-confirmation.html
+++ b/app/views/exporter-v13/imports-reject-confirmation.html
@@ -28,11 +28,17 @@ Import rejected
           html: "Your transaction number is <br><strong>GLW-REJECT-0001</strong>"
         }) }}
 
+        <p class="govuk-body govuk-!-padding-top-2">We’ve sent a confirmation email to <b>email@emailaddress.com</b>. </p>
+
+        <p class="govuk-body">We’ve also sent these details to the relevant UK regulatory authority. You do not need to send them anything else.</p>
+
         <h2 class="govuk-heading-m govuk-!-padding-top-2">
             What happens next?
         </h2>
 
-        <p class="govuk-body govuk-!-padding-top-2">You must contact your Agency Officer to agree what to do with the rejected waste import before you take any action. </p>
+        <p class="govuk-body">It’s your responsibility to contact your agency officer and agree with them what you want to do with the waste.</p>
+
+        <p class="govuk-body">Do not move or return the waste until you’ve got approval from them to do this. </p>
 
         <p class="govuk-body">The contact details are:</p>
   

--- a/app/views/exporter-v13/imports-reject-how-much.html
+++ b/app/views/exporter-v13/imports-reject-how-much.html
@@ -32,43 +32,45 @@ How much do you want to reject?
   <div class="govuk-grid-column-two-thirds">
 
             <div class="govuk-form-group">
-                <fieldset class="govuk-fieldset" aria-describedby="reason-hint">
+                <fieldset class="govuk-fieldset" aria-describedby="reject-amount-hint">
                   <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                     <h1 class="govuk-fieldset__heading">
                         How much do you want to reject?
                     </h1>
                   </legend>
-                  <div id="reason-hint" class="govuk-hint">
+                  <!-- <div id="reject-amount-hint" class="govuk-hint">
                     Select one option.
-                  </div>
+                  </div> -->
 
                   <div class="govuk-radios" data-module="govuk-radios">
 
                     <div class="govuk-radios__item">
-                      <input class="govuk-radios__input" id="reason" name="reason" type="radio" value="match" data-aria-controls="conditional-reason">
-                      <label class="govuk-label govuk-radios__label" for="reason">
+                      <input class="govuk-radios__input" id="reject-amount" name="reject-amount" type="radio" value="match" data-aria-controls="conditional-reject-amount">
+                      <label class="govuk-label govuk-radios__label" for="reject-amount">
                         I want to reject all of the waste import
                       </label>
                     </div>
 
                     <div class="govuk-radios__item">
-                      <input class="govuk-radios__input" id="reason-2" name="reason" type="radio" value="contaminated" data-aria-controls="conditional-reason-2">
-                      <label class="govuk-label govuk-radios__label" for="reason-2">
+                      <input class="govuk-radios__input" id="reject-amount-2" name="reject-amount" type="radio" value="contaminated" data-aria-controls="conditional-reject-amount-2">
+                      <label class="govuk-label govuk-radios__label" for="reject-amount-2">
                         I want to reject part of the waste import
                       </label>
                     </div>
-                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-reason-2">
+
+                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-reject-amount-2">
                       <div class="govuk-form-group">
-                        <label class="govuk-label" for="reason-by-contaminated">
-                            Enter how much as a percentage
+                        <label class="govuk-label" for="reject-amount-weight">
+                          Enter weight, in tonnes
                         </label>
-                        <div class="govuk-input__wrapper"><input class="govuk-input govuk-input--width-5" id="weight" name="weight" type="text" spellcheck="false">
-                            <div class="govuk-input__suffix" aria-hidden="true">%</div>
+                          <div class="govuk-input__wrapper"><input class="govuk-input govuk-input--width-5" id="reject-amount-weight" name="reject-amount-weight" value="{{ data['reject-amount-weight'] }}">
                           </div>
+                      
+                      <div><p class="govuk-body govuk-!-margin-top-6"><a class="govuk-link" href="#">Enter as a percentage (%)</a></p></div>
                       </div>
                     </div>
 
-                  </div>
+                  </div> 
                 </fieldset>
               </div>
 
@@ -76,9 +78,13 @@ How much do you want to reject?
 
               </form>
 
-              <a href="imports-reject-told-us.html"><button class="govuk-button" data-module="govuk-button">
+              <a href="imports-reject-whatnext-options.html"><button class="govuk-button" data-module="govuk-button">
                 Continue
               </button></a>
+
+              <div>
+                <a class="govuk-link" href="imports-dashboard.html">Cancel and return to green list overview</a></p>
+            </div> 
 
     </div>
   </div>

--- a/app/views/exporter-v13/imports-reject-search-results-1.html
+++ b/app/views/exporter-v13/imports-reject-search-results-1.html
@@ -1,0 +1,83 @@
+{% extends "../layouts/layout-importer-current.html" %}
+
+{% block pageTitle %}
+  Have you already told us about the import you want to reject?
+{% endblock %}
+
+{% block beforeContent %}
+  <div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      Prototype
+    </strong>
+    <span class="govuk-phase-banner__text">
+      Version 13 - This is not a live service.
+    </span>
+  </p>
+  </div>
+
+  {{ govukBackLink({
+    text: 'Back',
+    href: 'javascript:history.go(-1)'
+  }) }}
+
+
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <form class="form" method="post">
+
+      <h1 class="govuk-heading-l">
+        Submitted import search result
+      </h1>
+      <p class="govuk-body">Results <b>1</b> of <b>1</b></p>
+      
+    <!---------- SEARCH RESULTS TABLE ------------->
+
+      <table class="govuk-table govuk-!-margin-bottom-8">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Transaction number</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Date received</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Exporter</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td scope="row" class="govuk-table__cell"><a href="imports-reject-submitted.html">GLW-I- 28364</a></td>
+            <td class="govuk-table__cell">23 Feb 2023</td>
+            <td class="govuk-table__cell">Euromovement WEEE waste electric</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!---------- BUTTON ------------->
+            
+      <!--<div class="imports-name-button">
+        <button class="govuk-button" data-module="govuk-button">
+          Search again
+        </button>
+      </div>--> 
+
+        
+              
+    </form>
+               
+      <a href="imports-reject-search-submitted.html">
+        <button class="govuk-button" data-module="govuk-button">
+            Search again
+        </button>
+      </a>   
+
+      <div>
+        <a class="govuk-link" href="imports-dashboard.html">Cancel and return to green list overview</a></p>
+    </div> 
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/exporter-v13/imports-reject-search-submitted.html
+++ b/app/views/exporter-v13/imports-reject-search-submitted.html
@@ -1,0 +1,72 @@
+
+
+{% extends "../layouts/layout-importer-current.html" %}
+
+{% block pageTitle %}
+  Have you already told us about the import you want to reject?
+{% endblock %}
+
+{% block beforeContent %}
+  <div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      Prototype
+    </strong>
+    <span class="govuk-phase-banner__text">
+      Version 13 - This is not a live service.
+    </span>
+  </p>
+  </div>
+
+  {{ govukBackLink({
+    text: 'Back',
+    href: 'javascript:history.go(-1)'
+  }) }}
+
+
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" method="post">
+
+      <h1 class="govuk-heading-l">
+        Have you already told us about the import you want to reject?
+      </h1>
+      
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="event-name">
+          Enter your transaction number
+        </label>
+        <div id="reason-hint" class="govuk-hint">
+          For example, GLW-I-123456789
+        </div>
+        <input class="govuk-input" id="event-name" name="event-name" type="text">
+      </div>
+
+            
+      <div class="imports-name-button">
+        <button class="govuk-button" data-module="govuk-button">
+          Search for import
+        </button>
+      </div>
+
+      <div>
+        <a class="govuk-link" href="imports-dashboard.html">Cancel and return to green list overview</a></p>
+    </div> 
+              
+    </form>
+<!--               
+      <a href="imports-reject-how-much.html">
+        <button class="govuk-button" data-module="govuk-button">
+          Continue
+        </button>
+      </a> -->      
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/exporter-v13/imports-reject-submitted.html
+++ b/app/views/exporter-v13/imports-reject-submitted.html
@@ -474,17 +474,13 @@
 
         <!--------- DECLARATION ------------------->
 
-        <h2 class="govuk-heading-m">
-          Now submit import
-        </h2>
-
-        <p class="govuk-body">By submitting this import, you confirm that:</p>
-
-        <ul class="govuk-body">
-          <li>all the information you've provided is complete and correct to the best of your knowledge</li>
-          <li>there is an effective written contract with the overseas exporter arranging the shipment</li>
-          <li>you've taken legal responsibility of the waste</li>
-        </ul>
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span>
+            Check this is the import you want to reject
+          </strong>
+        </div>
 
         <div class="govuk-!-padding-bottom-4"></div>
 
@@ -499,12 +495,12 @@
           Confirm and submit
         </button> -->
         
-        <a href="imports-reject-whatnext-options.html"><button class="govuk-button" data-module="govuk-button">
-          Confirm and submit
+        <a href="imports-reject-confirmation.html"><button class="govuk-button govuk-button--warning" data-module="govuk-button">
+          Confirm and reject
         </button></a>
 
         <p class="govuk-body">
-          <a href="imports-dashboard" class="govuk-link">Cancel and return to green list waste overview</a>
+          <a href="imports-reject-search-submitted" class="govuk-link">This is not the correct import</a>
         </p>
 
       <!--</form>-->

--- a/app/views/exporter-v13/imports-reject-told-us.html
+++ b/app/views/exporter-v13/imports-reject-told-us.html
@@ -40,11 +40,11 @@
                       Have you already told us about the import you want to reject?
                     </h1>
                   </legend>
-                  <div id="reason-hint" class="govuk-hint">
+                  <!-- <div id="reason-hint" class="govuk-hint">
                     Select one option.
-                  </div>
+                  </div> -->
 
-                  <div class="govuk-radios" data-module="govuk-radios">
+                  <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
                     <div class="govuk-radios__item">
                       <input class="govuk-radios__input" id="told-us-yes" name="told-us" type="radio" value="yes" {{ checked("told-us", "yes") }}>
                       <label class="govuk-label govuk-radios__label" for="told-us-yes">
@@ -76,6 +76,10 @@
                   Continue
                 </button>
               </div>
+
+              <div>
+                <a class="govuk-link" href="imports-dashboard.html">Cancel and return to green list overview</a></p>
+            </div> 
               
             </form>
 <!--               <a href="imports-reject-how-much.html">

--- a/app/views/exporter-v13/imports-reject-unique-ref.html
+++ b/app/views/exporter-v13/imports-reject-unique-ref.html
@@ -49,7 +49,7 @@
   <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
-        Do you want to add your own reference to this import?
+        Do you want to add your own reference to this rejected import?
       </h1>
     </legend>
 

--- a/app/views/exporter-v13/imports-reject-whatnext-options.html
+++ b/app/views/exporter-v13/imports-reject-whatnext-options.html
@@ -79,7 +79,7 @@
                           <label class="govuk-label" for="reason-else">
                               Enter details
                           </label>
-                          <input class="govuk-input govuk-!-width-one-third" id="reason-else" name="reason-else">
+                          <textarea class="govuk-textarea govuk-!-width-two-thirds" id="reason-else" name="reason-else" rows="3"></textarea>
                         </div>
                       </div>
 
@@ -89,11 +89,15 @@
 
             <form class="form" method="post">
             </form>
-              <a href="imports-reject-confirmation.html">
+              <a href="imports-reject-told-us.html">
                 <button class="govuk-button" data-module="govuk-button">
-                  Submit and Continue
+                  Continue
                 </button>
               </a>
+
+              <div>
+                <a class="govuk-link" href="imports-dashboard.html">Cancel and return to green list overview</a></p>
+            </div> 
 
             
 

--- a/app/views/exporter-v13/imports-reject-why-options.html
+++ b/app/views/exporter-v13/imports-reject-why-options.html
@@ -1,5 +1,3 @@
-
-
 {% extends "../layouts/layout-importer-current.html" %}
 
 {% block pageTitle %}
@@ -31,8 +29,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-          
-
             <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset" aria-describedby="reason-hint">
                   <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -54,8 +50,9 @@
                     <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-reason">
                       <div class="govuk-form-group">
                         <label class="govuk-label" for="reason-by-match">
-                            Enter details                        </label>
-                        <input class="govuk-input govuk-!-width-one-third" id="reason-by-match" name="reason-by-match" type="match" spellcheck="false" autocomplete="match">
+                          Enter details
+                        </label>
+                        <textarea class="govuk-textarea govuk-!-width-two-thirds" id="reason-by-match" name="reason-by-match" rows="3"></textarea>
                       </div>
                     </div>
 
@@ -70,7 +67,7 @@
                         <label class="govuk-label" for="reason-by-contaminated">
                             Enter details
                         </label>
-                        <input class="govuk-input govuk-!-width-one-third" id="reason-by-contaminated" name="reason-by-contaminated" type="tel" autocomplete="tel">
+                        <textarea class="govuk-textarea govuk-!-width-two-thirds" id="reason-contaminated" name="reason-contaminated" rows="3"></textarea>
                       </div>
                     </div>
 
@@ -82,10 +79,10 @@
                     </div>
                     <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-reason-3">
                       <div class="govuk-form-group">
-                        <label class="govuk-label" for="reason-by-waste-type">
+                        <label class="govuk-label" for="reason-waste-type">
                             Enter details
                         </label>
-                        <input class="govuk-input govuk-!-width-one-third" id="reason-by-waste-type" name="reason-by-waste-type" type="tel" autocomplete="tel">
+                        <textarea class="govuk-textarea govuk-!-width-two-thirds" id="reason-waste-type" name="reason-waste-type" rows="3"></textarea>
                       </div>
                     </div>
 
@@ -100,7 +97,7 @@
                           <label class="govuk-label" for="reason-by-contract">
                               Enter details
                           </label>
-                          <input class="govuk-input govuk-!-width-one-third" id="reason-else" name="reason-else">
+                          <textarea class="govuk-textarea govuk-!-width-two-thirds" id="reason-contract" name="reason-contract" rows="3"></textarea>
                         </div>
                       </div>
 
@@ -117,7 +114,7 @@
                           <label class="govuk-label" for="reason-else">
                               Enter details
                           </label>
-                          <input class="govuk-input govuk-!-width-one-third" id="reason-else" name="reason-else">
+                          <textarea class="govuk-textarea govuk-!-width-two-thirds" id="reason-else" name="reason-else" rows="3"></textarea>
                         </div>
                       </div>
 
@@ -133,7 +130,9 @@
                 </button>
               </a>
 
-            
+              <div>
+                <a class="govuk-link" href="imports-dashboard.html">Cancel and return to green list overview</a></p>
+            </div> 
 
     </div>
   </div>

--- a/app/views/exporter-v13/point-of-exit.html
+++ b/app/views/exporter-v13/point-of-exit.html
@@ -21,7 +21,7 @@ Do you know the location at which the waste will leave the United Kingdom?
                     </h1>
                   </legend>
 
-                  <p class="govuk-body">For example, a town, port or terminal.</p>
+                  <p class="govuk-body">For example, the nearest town, port or terminal.</p>
 
                   <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">

--- a/app/views/exporter-v13/submitted-exports.html
+++ b/app/views/exporter-v13/submitted-exports.html
@@ -55,11 +55,11 @@
 
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header" >Your reference</th>
-          <th scope="col" class="govuk-table__header" aria-sort="ascending">Collection date</th>
-          <th scope="col" class="govuk-table__header" >Waste code</th>
-          <th scope="col" class="govuk-table__header" >Transaction number</th>
-          <th scope="col" class="govuk-table__header" >Action</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-20" >Your reference</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-15" aria-sort="ascending">Collection date</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter" >Waste code</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-12" >Transaction number</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-12" >Action</th>
         </tr>
       </thead>
 

--- a/app/views/exporter-v13/template-ec-code.html
+++ b/app/views/exporter-v13/template-ec-code.html
@@ -21,7 +21,7 @@ Do you have any EC list of wastes?
                     </h1>
                   </legend>
                   <div id="contact-hint" class="govuk-hint">
-                    An EWC code (European Waste Catalogue code) is also known as an EC list of waste.
+                    An EWC code (European Waste Catalogue code) is also known as an EC list of waste code. You must include all 6 digits.
                   </div>
                   <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">

--- a/app/views/exporter-v13/template-point-of-exit.html
+++ b/app/views/exporter-v13/template-point-of-exit.html
@@ -21,7 +21,7 @@ Do you know the location at which the waste will leave the United Kingdom?
                     </h1>
                   </legend>
 
-                  <p class="govuk-body">For example, a town, port or terminal.</p>
+                  <p class="govuk-body">For example, the nearest town, port or terminal.</p>
 
                   <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">

--- a/app/views/exporter-v13/view-submitted-export.html
+++ b/app/views/exporter-v13/view-submitted-export.html
@@ -204,7 +204,7 @@
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-              Point of leaving the UK
+              Location waste leaves the UK
             </dt>
             <dd class="govuk-summary-list__value">
               <p class="govuk-body">Felixstowe</p>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -42,7 +42,7 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">
                 <a href="exporter-v13/imports-dashboard">Import green list waste</a>
-              <td class="govuk-table__cell">37</td>
+              <td class="govuk-table__cell">WTS2023 Sprint 1</td>
               <td class="govuk-table__cell">
                 <ul class="govuk-list govuk-list--bullet">
                   <li>First version of importing greenlist waste</li>
@@ -53,9 +53,12 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">
                 <a href="exporter-v13/dashboard">V13</a>
-              <td class="govuk-table__cell">36 to 37</td>
+              <td class="govuk-table__cell">36 to 37<br>(Imports work included in WTS2023 Sprint 1)</td>
               <td class="govuk-table__cell">
                 <ul class="govuk-list govuk-list--bullet">
+                  <li>Imports feature added (accept and reject)</li>
+                  <li>Bug fixes<br>- Basel code typeahead (space causing codes not found)<br>- Character limit hint on waste descriptions</li>
+
                   <li>Iterations to templates from UR round 2</li>
                   <li>Added duplicate function to templates</li>
                   <li>Iterated radio options for estimate/actual (quantity and collection date)</li>


### PR DESCRIPTION
Imports reject
- completed with pre-completed 'submit' section to show users the expected journey without going through the whole thing.
- radio conditional reveals updated to textarea's
- search for a previous submitted import finished (all hard coded)
- changed the order of reject screens so check answers is last and goes to confirmation as all other journeys.

fixes
- made the delete button (for templates) destructive as it should have been