### PR TITLE
Bug fix - create export radio screen

### DIFF
--- a/app/views/exporter-v14/template-create-export-radios.html
+++ b/app/views/exporter-v14/template-create-export-radios.html
@@ -65,7 +65,7 @@
                   </div>
                 </div>
                 <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="which-template-4" name="which-template" type="radio" value="euromove-card" {{ checked("duplicate-which-template", "euromove-card") }}>
+                  <input class="govuk-radios__input" id="which-template-4" name="duplicate-which-template" type="radio" value="euromove-card" {{ checked("duplicate-which-template", "euromove-card") }}>
                   <label class="govuk-label govuk-radios__label" for="which-template-4">
                     Euromovement card waste movement                  
                     </label>
@@ -74,8 +74,8 @@
                     </div>
                 </div>
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="which-template-4" name="which-template" type="radio" value="fabric-society" {{ checked("duplicate-which-template", "fabric-society") }}>
-                    <label class="govuk-label govuk-radios__label" for="which-template-4">
+                    <input class="govuk-radios__input" id="which-template-5" name="duplicate-which-template" type="radio" value="fabric-society" {{ checked("duplicate-which-template", "fabric-society") }}>
+                    <label class="govuk-label govuk-radios__label" for="which-template-5">
                     Fabric Society Waste paper scrap                  
                     </label>
                     <div id="template-desc-item-hint" class="govuk-hint govuk-radios__hint">
@@ -84,7 +84,7 @@
                   </div>
                 <div class="govuk-radios__divider">or</div>
                 <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="which-template-6" name="which-template" type="radio" value="other" {{ checked("duplicate-which-template", "other") }}>
+                  <input class="govuk-radios__input" id="which-template-6" name="duplicate-which-template" type="radio" value="other" {{ checked("duplicate-which-template", "other") }}>
                   <label class="govuk-label govuk-radios__label" for="which-template-6">
                     one of my other templates
                   </label>

--- a/app/views/exporter-v14/template-submit-export-radios.html
+++ b/app/views/exporter-v14/template-submit-export-radios.html
@@ -74,8 +74,8 @@
                     </div>
                 </div>
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="which-template-4" name="which-template" type="radio" value="fabric-society" {{ checked("which-template", "fabric-society") }}>
-                    <label class="govuk-label govuk-radios__label" for="which-template-4">
+                    <input class="govuk-radios__input" id="which-template-5" name="which-template" type="radio" value="fabric-society" {{ checked("which-template", "fabric-society") }}>
+                    <label class="govuk-label govuk-radios__label" for="which-template-5">
                     Fabric Society Waste paper scrap                  
                     </label>
                     <div id="template-desc-item-hint" class="govuk-hint govuk-radios__hint">


### PR DESCRIPTION
Create export radios
- some radios were missing 'duplicate' from the "name".
- some radios didn't have unique IDs