### PR TITLE
Content corrections to imports and templates

### DIFF
--- a/app/views/exporter-v14/imports-code-add-another.html
+++ b/app/views/exporter-v14/imports-code-add-another.html
@@ -10,23 +10,23 @@
   <div class="govuk-grid-column-two-thirds">
         <form method="post" action="">
 
-          {% if data['code-count'] == '0' %}
+          {% if data['imports-code-count'] == '0' %}
     <h1 class="govuk-heading-l">
       You have added 1 EWC code
     </h1>
-          {% elseif data['code-count'] == '1' %}
+          {% elseif data['imports-code-count'] == '1' %}
     <h1 class="govuk-heading-l">
       You have added 2 EWC codes
     </h1>
-          {% elseif data['code-count'] == '2' %}
+          {% elseif data['imports-code-count'] == '2' %}
     <h1 class="govuk-heading-l">
       You have added 3 EWC codes
     </h1>
-          {% elseif data['code-count'] == '3' %}
+          {% elseif data['imports-code-count'] == '3' %}
     <h1 class="govuk-heading-l">
       You have added 4 EWC codes
     </h1>
-          {% elseif data['code-count'] == '4' %}
+          {% elseif data['imports-code-count'] == '4' %}
     <h1 class="govuk-heading-l">
       You have added 5 EWC codes
     </h1>

--- a/app/views/exporter-v14/imports-exporter-address-manual.html
+++ b/app/views/exporter-v14/imports-exporter-address-manual.html
@@ -11,7 +11,7 @@
       <form class="form" method="post">
 
       <h1 class="govuk-heading-l">
-        What's the exporter's address?
+        What's the importer's address?
       </h1>
 
     <div class="govuk-form-group">

--- a/app/views/exporter-v14/imports-quantity.html
+++ b/app/views/exporter-v14/imports-quantity.html
@@ -19,7 +19,7 @@ Do you know the quantity of waste?
           <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
               <h1 class="govuk-fieldset__heading">
-                Enter the actual quantity of waste
+                Enter the actual waste quantity
               </h1>
             </legend>
 
@@ -61,7 +61,6 @@ Do you know the quantity of waste?
                     Enter the volume
                   </label>
                   <div class="govuk-input__wrapper"><input class="govuk-input govuk-input--width-5" id="imports-volume" name="imports-quantity-volume" value="{{ data['imports-quantity-volume'] }}" type="text" spellcheck="false">
-                    <div class="govuk-input__suffix" aria-hidden="true">kg</div>
                   </div>
                 </div>
               </div>

--- a/app/views/exporter-v14/imports-reject-check-your-answers.html
+++ b/app/views/exporter-v14/imports-reject-check-your-answers.html
@@ -32,7 +32,7 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key govuk-!-width-one-third">
-          <h2 class="govuk-heading-m">Your unique reference</h2>
+          <h2 class="govuk-heading-m">Your reference</h2>
         </dt>
         <dd class="govuk-summary-list__value">
         </dd>
@@ -42,7 +42,7 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Unique reference
+          Your own reference
         </dt>
         <dd class="govuk-summary-list__value">
           <!-- DYNAMIC national code (set in local routes.js)-->

--- a/app/views/exporter-v14/imports-reject-submitted.html
+++ b/app/views/exporter-v14/imports-reject-submitted.html
@@ -33,7 +33,7 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key govuk-!-width-one-third">
-          <h2 class="govuk-heading-m">Your unique reference</h2>
+          <h2 class="govuk-heading-m">Your reference</h2>
         </dt>
         <dd class="govuk-summary-list__value">
         </dd>
@@ -43,7 +43,7 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Unique reference
+          Your own reference
         </dt>
         <dd class="govuk-summary-list__value">
           <!-- DYNAMIC national code (set in local routes.js)-->

--- a/app/views/exporter-v14/template-carrier-transport-1b.html
+++ b/app/views/exporter-v14/template-carrier-transport-1b.html
@@ -27,7 +27,7 @@
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="transport-shipping" name="transport" type="radio" value="shipping" {{ checked("transport", "shipping") }}>
               <label class="govuk-label govuk-radios__label" for="transport-shipping">
-                Shipping Container
+                Shipping container
               </label>
             </div>
 

--- a/app/views/exporter-v14/template-carrier-transport-2b.html
+++ b/app/views/exporter-v14/template-carrier-transport-2b.html
@@ -27,7 +27,7 @@
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="transport-shipping-2" name="transport-2" type="radio" value="shipping" {{ checked("transport-2", "shipping") }}>
               <label class="govuk-label govuk-radios__label" for="transport-shipping-2">
-                Shipping Container
+                Shipping container
               </label>
             </div>
 

--- a/app/views/exporter-v14/template-carrier-transport-3b.html
+++ b/app/views/exporter-v14/template-carrier-transport-3b.html
@@ -27,7 +27,7 @@
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="transport-shipping-3" name="transport-3" type="radio" value="shipping" {{ checked("transport-3", "shipping") }}>
               <label class="govuk-label govuk-radios__label" for="transport-shipping-3">
-                Shipping Container
+                Shipping container
               </label>
             </div>
 

--- a/app/views/exporter-v14/template-carrier-transport-4b.html
+++ b/app/views/exporter-v14/template-carrier-transport-4b.html
@@ -27,7 +27,7 @@
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="transport-shipping-4" name="transport-4" type="radio" value="shipping" {{ checked("transport-4", "shipping") }}>
               <label class="govuk-label govuk-radios__label" for="transport-shipping-4">
-                Shipping Container
+                Shipping container
               </label>
             </div>
 

--- a/app/views/exporter-v14/template-carrier-transport-5b.html
+++ b/app/views/exporter-v14/template-carrier-transport-5b.html
@@ -27,7 +27,7 @@
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="transport-shipping-5" name="transport-5" type="radio" value="shipping" {{ checked("transport-5", "shipping") }}>
               <label class="govuk-label govuk-radios__label" for="transport-shipping-5">
-                Shipping Container
+                Shipping container
               </label>
             </div>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -57,7 +57,8 @@
               <td class="govuk-table__cell">
                 <ul class="govuk-list govuk-list--bullet">
                   <li>Iterations to exports</li>
-                  <li>Iterations to templates</li>
+                  <li>Iterations to templates<br>
+                    - Waste carrier journey (details for first to fifth carriers)</li>
                 </ul>
                 </td>
             </tr>
@@ -80,7 +81,9 @@
               <td class="govuk-table__cell">
                 <ul class="govuk-list govuk-list--bullet">
                   <li>Imports feature added (accept and reject)</li>
-                  <li>Bug fixes<br>- Basel code typeahead (space causing codes not found)<br>- Character limit hint on waste descriptions</li>
+                  <li>Bug fixes<br>
+                    - Basel code typeahead (space causing codes not found)<br>
+                    - Character limit hint on waste descriptions</li>
 
                   <li>Iterations to templates from UR round 2</li>
                   <li>Added duplicate function to templates</li>


### PR DESCRIPTION
- incorrect H1 on imports manual address
- incorrect H1 on imports quantity
- update reference text on imports reject CYA
- update reference text on imports reject submitted
- correct 'container' with lowercase 'c'