### PR TITLE
Added interim sites + progress tag to waste codes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -177,6 +177,40 @@ if ($('#recovery-operation-typeahead-container').length > 0) {
   })
 }
 
+// Part of the Interim site journey
+if ($('#first-recovery-operation-typeahead-container').length > 0) {
+  element = document.querySelector('#first-recovery-operation-typeahead-container')
+  id = 'first-recovery-operation-typeahead' // To match it to the existing <label>.
+
+  accessibleAutocomplete ({
+    element: element,
+    defaultValue: element.getAttribute('data-default-value'),
+    id: id,
+    name: id,
+    source: recoveryOperation,
+    minLength: 1,
+    showAllValues: true,
+    dropdownArrow: () => ''
+  })
+}
+
+// Part of the Interim site journey
+if ($('#second-recovery-operation-typeahead-container').length > 0) {
+  element = document.querySelector('#second-recovery-operation-typeahead-container')
+  id = 'second-recovery-operation-typeahead' // To match it to the existing <label>.
+
+  accessibleAutocomplete ({
+    element: element,
+    defaultValue: element.getAttribute('data-default-value'),
+    id: id,
+    name: id,
+    source: recoveryOperation,
+    minLength: 1,
+    showAllValues: true,
+    dropdownArrow: () => ''
+  })
+}
+
 // D-code autocomplete
 const dCode = [
   'D1: Deposit into or onto land',
@@ -2185,6 +2219,40 @@ if ($('#export-dispatch-typeahead-container').length > 0) {
 if ($('#interim-site-typeahead-container').length > 0) {
   element = document.querySelector('#interim-site-typeahead-container')
   id = 'interim-site-typeahead' // To match it to the existing <label>.
+
+  accessibleAutocomplete ({
+    element: element,
+    defaultValue: element.getAttribute('data-default-value'),
+    id: id,
+    name: id,
+    source: countryList,
+    minLength: 1,
+    showAllValues: true,
+    dropdownArrow: () => ''
+  })
+}
+
+// First recovery autocomplete
+if ($('#first-recovery-typeahead-container').length > 0) {
+  element = document.querySelector('#first-recovery-typeahead-container')
+  id = 'first-recovery-typeahead' // To match it to the existing <label>.
+
+  accessibleAutocomplete ({
+    element: element,
+    defaultValue: element.getAttribute('data-default-value'),
+    id: id,
+    name: id,
+    source: countryList,
+    minLength: 1,
+    showAllValues: true,
+    dropdownArrow: () => ''
+  })
+}
+
+// Second recovery autocomplete
+if ($('#second-recovery-typeahead-container').length > 0) {
+  element = document.querySelector('#second-recovery-typeahead-container')
+  id = 'second-recovery-typeahead' // To match it to the existing <label>.
 
   accessibleAutocomplete ({
     element: element,

--- a/app/views/exporter-v14/_routes.js
+++ b/app/views/exporter-v14/_routes.js
@@ -1745,20 +1745,10 @@ router.post('/carrier-collect-address-manual', function(req, res) {
     res.redirect('waste-generator');
 })
 
-//-----------------------------------------------------------
+//---------------- RECOVERY LAB OR INTERIM -------------------------------------------
 
 
 // recovery-facility-laboratory
-router.post('/waste-treated', function(req, res) {
-    req.session.data['recovery-facility-or-laboratory-status'] = "Completed";
-
-    if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
-        res.redirect('check-your-answers');
-    } else {
-        res.redirect('recovery-facility-laboratory');
-    }
-})
-
 router.post('/recovery-facility-laboratory', function(req, res) {
     req.session.data['recovery-facility-or-laboratory-status'] = "Completed";
 
@@ -1768,6 +1758,7 @@ router.post('/recovery-facility-laboratory', function(req, res) {
         res.redirect('recovery-operation');
     }
 })
+
 
 // recovery-operation
 router.post('/recovery-operation', function(req, res) {
@@ -1780,6 +1771,114 @@ router.post('/recovery-operation', function(req, res) {
     }
 })
 
+
+// interim-site
+router.post('/interim-site', function(req, res) {
+    req.session.data['interim-site-status'] = "Completed";
+
+    if (req.session.data['interim-site'] == 'yes') {
+        res.redirect('interim-site-details');
+    } else if (req.session.data['interim-site'] == 'no') {
+        res.redirect('recovery-facilities-more');
+    }
+    
+})
+
+
+// interim-site-details
+router.post('/interim-site-details', function(req, res) {
+    req.session.data['interim-site-details-status'] = "Completed";
+
+    if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
+        res.redirect('check-your-answers');
+    } else {
+        res.redirect('interim-site-recovery-code');
+    }
+})
+
+
+// interim-site-recovery-code
+router.post('/interim-site-recovery-code', function(req, res) {
+    req.session.data['interim-site-recovery-code-status'] = "Completed";
+
+    if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
+        res.redirect('check-your-answers');
+    } else {
+        res.redirect('recovery-facilities-more');
+    }
+})
+
+
+// recovery-facilities-more
+router.post('/recovery-facilities-more', function(req, res) {
+
+    if (req.session.data['recovery-more'] == 'yes') {
+        res.redirect('recovery-facility-first');
+    } else if (req.session.data['recovery-more'] == 'no') {
+        res.redirect('recovery-facility-laboratory');
+    }
+    
+})
+
+
+// recovery-facility-first
+router.post('/recovery-facility-first', function(req, res) {
+    req.session.data['recovery-facility-first-status'] = "Completed";
+
+    if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
+        res.redirect('check-your-answers');
+    } else {
+        res.redirect('recovery-code-first');
+    }
+})
+
+
+// recovery-code-first
+router.post('/recovery-code-first', function(req, res) {
+    req.session.data['recovery-code-first-status'] = "Completed";
+
+    if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
+        res.redirect('check-your-answers');
+    } else {
+        res.redirect('recovery-facility-second');
+    }
+})
+
+
+// recovery-facility-second
+router.post('/recovery-facility-second', function(req, res) {
+    req.session.data['recovery-facility-second-status'] = "Completed";
+
+    if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
+        res.redirect('check-your-answers');
+    } else {
+        res.redirect('recovery-code-second');
+    }
+})
+
+// recovery-code-second
+router.post('/recovery-code-second', function(req, res) {
+    req.session.data['recovery-code-second-status'] = "Completed";
+
+    if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
+        res.redirect('check-your-answers');
+    } else {
+        res.redirect('recovery-facilities');
+    }
+})
+
+
+// recovery-facilities
+router.post('/recovery-facilities', function(req, res) {
+
+    if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
+        res.redirect('check-your-answers');
+    } else {
+        res.redirect('prenotify');
+    }
+})
+
+
 //-----------------------------------------------------------
 
 // waste-codes-and-description
@@ -1788,9 +1887,11 @@ router.post('/waste-codes-and-description', function(req, res) {
         res.redirect('check-your-answers');
     } else {
         if (req.session.data['code'] == 'not-applicable') {
+            req.session.data['usual-description-of-the-waste-status'] = "In Progress";
             res.redirect('ec-code-2');
           } else {
-              res.redirect('ec-code');
+            req.session.data['usual-description-of-the-waste-status'] = "In Progress";
+            res.redirect('ec-code');
           }
     }
 })
@@ -1798,8 +1899,8 @@ router.post('/waste-codes-and-description', function(req, res) {
 //-----------------------------------------------------------
 
 router.post('/national-code', function(req, res) {
-    //req.session.data['usual-description-of-the-waste-status'] = "Completed";
-    req.session.data['usual-description-of-the-waste-status'] = "In Progress";
+    req.session.data['usual-description-of-the-waste-status'] = "Completed";
+    //req.session.data['usual-description-of-the-waste-status'] = "In Progress";
 
     if ((req.session.data.gPreviousLocation).includes('check-your-answers')) {
         res.redirect('check-your-answers');
@@ -2115,6 +2216,7 @@ router.get('/template-carrier-check', function (req, res) {
 
   //------ EWC code counter
   router.post('/ec-code', function(req, res) {
+
           if(req.session.data['ec-code']=='Yes'){
             if(typeof req.session.data['code-count'] == "undefined"){
               req.session.data['code-count'] = 0;

--- a/app/views/exporter-v14/interim-site-details.html
+++ b/app/views/exporter-v14/interim-site-details.html
@@ -1,0 +1,103 @@
+{% extends "../layouts/layout-exporter-current.html" %}
+
+{% block pageTitle %}
+  Interim site details
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+            <form class="form" method="post">
+
+            <h1 class="govuk-heading-l">
+                Interim site details
+            </h1>
+
+            <div class="govuk-form-group">
+            <label class="govuk-label" for="interim-site-name">
+                Interim site name
+              <span class="govuk-visually-hidden">line 1 of 2</span>
+            </label>
+            <input class="govuk-input govuk-!-width-three-quarters" id="interim-site-name" name="interim-site-name" type="text" value="{{data['interim-site-name']}}">
+          </div>
+
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="interim-site-address">
+              Address
+            </label>
+            <textarea class="govuk-textarea" id="interim-site-address" name="interim-site-address" rows="5" autocomplete="street-address">{{ data['interim-site-address'] }}</textarea>
+          </div>
+
+          <h2 class="govuk-label-wrapper">
+            <label class="govuk-label">
+              Country
+            </label>
+          </h2>
+          <div id="interim-site-typeahead-container" class="govuk-!-width-two-thirds govuk-!-margin-bottom-6" data-default-value="{{ data['interim-site-typeahead'] }}">
+          </div>
+
+          <div class="govuk-!-padding-bottom-6"></div>
+
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                <h1 class="govuk-fieldset__heading">
+                  Contact details
+                </h1>
+              </legend>
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="interim-site-full-name">
+                  Full name
+                </label>
+                <input class="govuk-input govuk-!-width-three-quarters" id="interim-site-full-name" name="interim-site-full-name" type="text" value="{{data['interim-site-full-name']}}">
+              </div>
+
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="interim-site-email">
+                  Email address
+                </label>
+                <input class="govuk-input govuk-!-width-one-half" id="interim-site-email" name="interim-site-email" type="email" value="{{data['interim-site-email']}}">
+              </div>
+
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="interim-site-phone">
+                  Phone number
+                </label>
+                <!-- <div id="contact-hint" class="govuk-hint">
+                   Include the country code for international numbers.
+                </div> -->
+                <input class="govuk-input govuk-input--width-4 govuk-!-margin-right-2" id="interim-site-phone-code" name="interim-site-phone-code" type="tel" value="0049{{data['interim-site-phone-code']}}">
+                <input class="govuk-input govuk-!-width-one-third" id="interim-site-phone" name="interim-site-phone" type="tel" value=" {{data['interim-site-phone']}}">
+              </div>
+
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="interim-site-fax">
+                  Fax number (optional)
+                </label>
+                <!-- <div id="contact-hint" class="govuk-hint">
+                   Include the country code for international numbers.
+                </div> -->
+                <input class="govuk-input govuk-input--width-4 govuk-!-margin-right-2" id="interim-site-fax-code" name="interim-site-fax-code" type="tel" value="0049{{data['interim-site-fax-code']}}">
+                <input class="govuk-input govuk-!-width-one-third" id="interim-site-fax" name="interim-site-fax" type="tel" value="{{data['interim-site-fax']}}">
+              </div>
+
+              <div class="govuk-!-padding-bottom-2"></div>
+
+
+            </fieldset>
+          </div>
+
+        {{ govukButton({
+          text: 'Save and continue'
+        }) }}
+
+        {% include "./includes/return-to-link.html" %}
+
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/exporter-v14/interim-site-recovery-code.html
+++ b/app/views/exporter-v14/interim-site-recovery-code.html
@@ -1,0 +1,55 @@
+{% extends "../layouts/layout-exporter-current.html" %}
+
+{% block pageTitle %}
+Interim site - What is the recovery code?
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" action="">
+
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h1 class="govuk-fieldset__heading">
+                    What is the recovery code?
+                </h1>
+              </legend>
+              <div class="govuk-radios" data-module="govuk-radios">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="interim-rcode" name="interim-rcode" type="radio" value="R12">
+                  <label class="govuk-label govuk-radios__label" for="interim-rcode">
+                    <b>R12:</b> Exchange of wastes for submission to any of the operations numbered R01 to R11 
+                  </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="interim-rcode-2" name="interim-rcode" type="radio" value="R13">
+                  <label class="govuk-label govuk-radios__label" for="interim-rcode-2">
+                    <b>R13:</b> Storage of wastes pending any of the operations numbered R01 to R12 (excluding temporary storage, pending collection, on the site where it is produced)
+                  </label>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+
+          <div class="govuk-button-group">
+            <button class="govuk-button" data-module="govuk-button">
+              Continue
+            </button>
+          </div>
+    
+        </form>
+
+      <!-- {{ govukButton({
+        text: 'Continue'
+      }) }} -->
+
+      {% include "./includes/return-to-link.html" %}
+        
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/exporter-v14/interim-site.html
+++ b/app/views/exporter-v14/interim-site.html
@@ -1,95 +1,68 @@
 {% extends "../layouts/layout-exporter-current.html" %}
 
 {% block pageTitle %}
-  What is the address of the interim site? - Export green list waste
+  Will the waste go to an interim site?
 {% endblock %}
 
 {% block content %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <form method="post" action="">
 
-      <h1 class="govuk-heading-l">
-        What is the address of the interim site? 
-      </h1>
-
-      <form class="form" method="post">
-
-        {% call govukFieldset({
-          legend: {
-            text: "Address",
-            classes: "govuk-fieldset__legend--m"
-          }
-        }) %}
-
-          {{ govukInput({
-            label: {
-              html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
-            },
-            id: "interim-site-address-line-1",
-            name: "interim-site-address-line-1",
-            value: data['interim-site-address-line-1'],
-            autocomplete: "address-line1"
-          }) }}
-        
-          {{ govukInput({
-            label: {
-              html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
-            },
-            id: "interim-site-address-line-2",
-            name: "interim-site-address-line-2",
-            value: data['interim-site-address-line-2'],
-            autocomplete: "address-line2"
-          }) }}
-        
-          {{ govukInput({
-            label: {
-              text: "Town or city"
-            },
-            classes: "govuk-!-width-two-thirds",
-            id: "interim-site-address-town",
-            name: "interim-site-address-town",
-            value: data['interim-site-address-town'],
-            autocomplete: "address-level2"
-          }) }}
-        
-          {{ govukInput({
-            label: {
-              text: "Region, state or county"
-            },
-            classes: "govuk-!-width-two-thirds",
-            id: "interim-site-address-county",
-            name: "interim-site-address-county",
-            value: data['interim-site-address-county']
-          }) }}
-        
-          {{ govukInput({
-            label: {
-              text: "Postcode or ZIP code"
-            },
-            classes: "govuk-input--width-10",
-            id: "interim-site-address-postcode",
-            name: "interim-site-address-postcode",
-            value: data['interim-site-address-postcode'],
-            autocomplete: "postal-code"
-          }) }}
-        
-          <h2 class="govuk-label-wrapper">
-            <label class="govuk-label">
-              Country
-            </label>
-          </h2>
-          <div id="interim-site-typeahead-container" class="govuk-!-width-two-thirds govuk-!-margin-bottom-6" data-default-value="{{ data['interim-site-typeahead'] }}">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="interim-site-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              Will the waste go to an interim site before it reaches the final recovery facility?
+            </h1>
+          </legend>
+          <div id="interim-site-hint" class="govuk-hint">
+            This includes for storage or processing.
           </div>
+          <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="interim-site" name="interim-site" type="radio" value="yes">
+              <label class="govuk-label govuk-radios__label" for="interim-site">
+                Yes
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="interim-site-2" name="interim-site" type="radio" value="no">
+              <label class="govuk-label govuk-radios__label" for="interim-site">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
 
-        {% endcall %}
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            What is an interim site?
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          An interim site is an authorised facility where the waste gets limited additional processing. For example, at an interim site different plastic waste grades could be separated and stored temporarily before they move to one or more final recovery facilities.
+        </div>
+      </details>
 
-        {{ govukButton({
-          text: 'Save and continue',
-          classes: 'govuk-!-margin-top-2'
-        }) }}
+      <div class="govuk-button-group">
+        <button class="govuk-button" data-module="govuk-button">
+          Continue
+        </button>
+      </div>
+      <!-- <a class="govuk-link" href="javascript:history.go(-1)">Cancel and return to template list</a> -->
 
-      </form>
+    </form>
+
+      <!-- {{ govukButton({
+        text: 'Continue'
+      }) }} -->
+
+      {% include "./includes/return-to-link.html" %}
+        
 
     </div>
   </div>

--- a/app/views/exporter-v14/prenotify.html
+++ b/app/views/exporter-v14/prenotify.html
@@ -85,6 +85,10 @@
               </span>
               {% if data['usual-description-of-the-waste-status'] == null or data['usual-description-of-the-waste-status'] == 'Not started' %}
                 <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="provide-waste-identification-details-status">Not started</strong>
+
+              {% elif data['usual-description-of-the-waste-status'] == 'In Progress' %}
+                <strong class="govuk-tag app-task-list__tag" id="provide-waste-identification-details-status">In Progress</strong>
+
               {% elif data['usual-description-of-the-waste-status'] == 'Completed' %}
                 <strong class="govuk-tag app-task-list__tag" id="provide-waste-identification-details-status">Completed</strong>
               {% endif %}
@@ -120,12 +124,12 @@
               </span>
              -->
 
-              {% if data['usual-description-of-the-waste-status'] == null or data['usual-description-of-the-waste-status'] == 'Not started' and
-              data['quantity-status'] == null or data['quantity-status'] == 'Not started' %}
+              {% if data['usual-description-of-the-waste-status'] == null or data['usual-description-of-the-waste-status'] == 'Not started' %}
               <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="submit-export">Cannot start yet</strong>
 
-              {% elseif data['quantity-status'] == null or data['quantity-status'] == 'Not started' %}
+              {% elseif data['usual-description-of-the-waste-status'] == 'In Progress' or data['quantity-status'] == null or data['quantity-status'] == 'Not started' %}
                 <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="quantity-status">Not started</strong>
+                
               {% elif data['quantity-status'] == 'Completed' %}
                 <strong class="govuk-tag app-task-list__tag" id="quantity-status">Completed</strong>
               {% endif %}
@@ -280,7 +284,7 @@
                   <a href="recovery-facility-laboratory" aria-describedby="eligibility-status">
                   Laboratory details
                   {% elseif data ['code'] == "basel" or data ['code'] == "oecd" or data ['code'] == "annex-a" or data ['code'] == "annex-b" %}
-                  <a href="recovery-facility-laboratory" aria-describedby="eligibility-status">
+                  <a href="interim-site.html" aria-describedby="eligibility-status">
                   Recovery facility details
                   {% else %}
                   <span class="app-task-list__task-name">

--- a/app/views/exporter-v14/recovery-code-first.html
+++ b/app/views/exporter-v14/recovery-code-first.html
@@ -1,0 +1,41 @@
+{% extends "../layouts/layout-exporter-current.html" %}
+
+{% block pageTitle %}
+  What is the recovery code?
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form class="form" method="post">
+
+        <div class="govuk-form-group">
+
+          <h1 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--l">
+              What is the recovery code?
+            </label>
+          </h1>
+          <div id="rcode-first-typeahead" class="govuk-hint">
+            Choose from the list or start typing
+          </div>
+          <div id="first-recovery-operation-typeahead-container" data-default-value="{{ data['first-recovery-operation-typeahead'] }}">
+          </div>
+
+        </div>
+
+        {{ govukButton({
+          text: 'Save and continue'
+        }) }}
+
+        {% include "./includes/return-to-link.html" %}
+
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/exporter-v14/recovery-code-second.html
+++ b/app/views/exporter-v14/recovery-code-second.html
@@ -1,0 +1,41 @@
+{% extends "../layouts/layout-exporter-current.html" %}
+
+{% block pageTitle %}
+  What is the recovery code?
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form class="form" method="post">
+
+        <div class="govuk-form-group">
+
+          <h1 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--l">
+              What is the recovery code?
+            </label>
+          </h1>
+          <div id="rcode-second-typeahead" class="govuk-hint">
+            Choose from the list or start typing
+          </div>
+          <div id="second-recovery-operation-typeahead-container" data-default-value="{{ data['second-recovery-operation-typeahead'] }}">
+          </div>
+
+        </div>
+
+        {{ govukButton({
+          text: 'Save and continue'
+        }) }}
+
+        {% include "./includes/return-to-link.html" %}
+
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/exporter-v14/recovery-facilities-more.html
+++ b/app/views/exporter-v14/recovery-facilities-more.html
@@ -1,0 +1,58 @@
+{% extends "../layouts/layout-exporter-current.html" %}
+
+{% block pageTitle %}
+  WWill the waste go to more than one recovery facility?
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" action="">
+
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="recovery-more-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              Will the waste go to more than one recovery facility?
+            </h1>
+          </legend>
+          <div id="recovery-more-hint" class="govuk-hint">
+            This includes for storage or processing.
+          </div>
+          <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="recovery-more" name="recovery-more" type="radio" value="yes">
+              <label class="govuk-label govuk-radios__label" for="recovery-more">
+                Yes
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="recovery-more-2" name="recovery-more" type="radio" value="no">
+              <label class="govuk-label govuk-radios__label" for="recovery-more-2">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <div class="govuk-button-group">
+        <button class="govuk-button" data-module="govuk-button">
+          Continue
+        </button>
+      </div>
+
+    </form>
+
+      <!-- {{ govukButton({
+        text: 'Continue'
+      }) }}
+ -->
+      {% include "./includes/return-to-link.html" %}
+        
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/exporter-v14/recovery-facilities.html
+++ b/app/views/exporter-v14/recovery-facilities.html
@@ -1,0 +1,78 @@
+{% extends "../layouts/layout-exporter-current.html" %}
+
+{% block pageTitle %}
+  You have added 1 waste recovery facility
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+        <form method="post" action="">
+
+          <h1 class="govuk-heading-l">
+            Recovery facilities
+          </h1>
+
+          <h2 class="govuk-heading-m">First recovery facility</h2>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-1">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                  <p class="govuk-body">{{data['first-recovery-name']}}<br>
+                     {{ data['first-recovery-typeahead'] }}<br><br>
+                     {{ data['first-recovery-operation-typeahead'] }}</p>
+                </dt>
+                <dd class="govuk-summary-list__value">
+        
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="">
+                    Change<span class="govuk-visually-hidden"> change</span>
+                </a>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                </dd>
+            </div>
+            </dl>
+
+          <br>
+          <br>
+
+          <h2 class="govuk-heading-m">Second recovery facility</h2>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-1">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                  <p class="govuk-body">{{data['second-recovery-name']}}<br>
+                    {{ data['second-recovery-typeahead'] }}<br><br>
+                     {{ data['second-recovery-operation-typeahead'] }}</p>
+                </dt>
+                <dd class="govuk-summary-list__value">
+        
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="">
+                    Change<span class="govuk-visually-hidden"> change</span>
+                </a>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <a class="govuk-link" href="">
+                    Remove<span class="govuk-visually-hidden"> remove</span>
+                  </a>
+                </dd>
+            </div>
+            </dl>
+
+            <div class="govuk-!-padding-bottom-8"></div>
+
+    <button class="govuk-button" data-module="govuk-button">
+      Save and continue
+    </button>
+   
+    {% include "./includes/return-to-link.html" %}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/exporter-v14/recovery-facility-first.html
+++ b/app/views/exporter-v14/recovery-facility-first.html
@@ -1,0 +1,106 @@
+{% extends "../layouts/layout-exporter-current.html" %}
+
+{% block pageTitle %}
+  First recovery facility details
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+            <form class="form" method="post">
+
+          <h1 class="govuk-heading-l">
+            First recovery facility details
+          </h1>
+
+            <div class="govuk-form-group">
+            <label class="govuk-label" for="first-recovery-name">
+                Recovery facility name
+              <span class="govuk-visually-hidden">line 1 of 2</span>
+            </label>
+            <input class="govuk-input govuk-!-width-three-quarters" id="first-recovery-name" name="first-recovery-name" type="text" value="{{data['first-recovery-name']}}">
+          </div>
+
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="first-recovery-address">
+              Address
+            </label>
+            <textarea class="govuk-textarea" id="first-recovery-address" name="first-recovery-address" rows="5" autocomplete="street-address">{{ data['first-recovery-address'] }}</textarea>
+          </div>
+
+          <h2 class="govuk-label-wrapper">
+            <label class="govuk-label">
+              Country
+            </label>
+            <div id="first-recovery-country-hint" class="govuk-hint">
+              We’ll also use this as the importing country.
+            </div>
+          </h2>
+          <div id="first-recovery-typeahead-container" class="govuk-!-width-two-thirds govuk-!-margin-bottom-6" data-default-value="{{ data['first-recovery-typeahead'] }}">
+          </div>
+
+          <div class="govuk-!-padding-bottom-6"></div>
+
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                <h1 class="govuk-fieldset__heading">
+                  Contact details
+                </h1>
+              </legend>
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="first-recovery-full-name">
+                  Full name
+                </label>
+                <input class="govuk-input govuk-!-width-three-quarters" id="first-recovery-full-name" name="first-recovery-full-name" type="text" value="{{data['first-recovery-full-name']}}">
+              </div>
+
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="first-recovery-email">
+                  Email address
+                </label>
+                <input class="govuk-input govuk-!-width-one-half" id="first-recovery-email" name="first-recovery-email" type="email" value="{{data['first-recovery-email']}}">
+              </div>
+
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="first-recovery-phone">
+                  Phone number
+                </label>
+                <!-- <div id="contact-hint" class="govuk-hint">
+                   Include the country code for international numbers.
+                </div> -->
+                <input class="govuk-input govuk-input--width-4 govuk-!-margin-right-2" id="first-recovery-phone-code" name="first-recovery-phone-code" type="tel" value="0049{{data['first-recovery-phone-code']}}">
+                <input class="govuk-input govuk-!-width-one-third" id="first-recovery-phone" name="first-recovery-phone" type="tel" value=" {{data['first-recovery-phone']}}">
+              </div>
+
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="first-recovery-fax">
+                  Fax number (optional)
+                </label>
+                <!-- <div id="contact-hint" class="govuk-hint">
+                   Include the country code for international numbers.
+                </div> -->
+                <input class="govuk-input govuk-input--width-4 govuk-!-margin-right-2" id="first-recovery-fax-code" name="first-recovery-fax-code" type="tel" value="0049{{data['first-recovery-fax-code']}}">
+                <input class="govuk-input govuk-!-width-one-third" id="first-recovery-fax" name="first-recovery-fax" type="tel" value="{{data['first-recovery-fax']}}">
+              </div>
+
+              <div class="govuk-!-padding-bottom-2"></div>
+
+
+            </fieldset>
+          </div>
+
+        {{ govukButton({
+          text: 'Save and continue'
+        }) }}
+
+        {% include "./includes/return-to-link.html" %}
+
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/exporter-v14/recovery-facility-second.html
+++ b/app/views/exporter-v14/recovery-facility-second.html
@@ -1,0 +1,106 @@
+{% extends "../layouts/layout-exporter-current.html" %}
+
+{% block pageTitle %}
+  Second recovery facility details
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+            <form class="form" method="post">
+
+          <h1 class="govuk-heading-l">
+            Second recovery facility details
+          </h1>
+
+            <div class="govuk-form-group">
+            <label class="govuk-label" for="second-recovery-name">
+                Recovery facility name
+              <span class="govuk-visually-hidden">line 1 of 2</span>
+            </label>
+            <input class="govuk-input govuk-!-width-three-quarters" id="second-recovery-name" name="second-recovery-name" type="text" value="{{data['second-recovery-name']}}">
+          </div>
+
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="second-recovery-address">
+              Address
+            </label>
+            <textarea class="govuk-textarea" id="second-recovery-address" name="second-recovery-address" rows="5" autocomplete="street-address">{{ data['second-recovery-address'] }}</textarea>
+          </div>
+
+          <h2 class="govuk-label-wrapper">
+            <label class="govuk-label">
+              Country
+            </label>
+            <div id="second-recovery-country-hint" class="govuk-hint">
+              We’ll also use this as the importing country.
+            </div>
+          </h2>
+          <div id="second-recovery-typeahead-container" class="govuk-!-width-two-thirds govuk-!-margin-bottom-6" data-default-value="{{ data['second-recovery-typeahead'] }}">
+          </div>
+
+          <div class="govuk-!-padding-bottom-6"></div>
+
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                <h1 class="govuk-fieldset__heading">
+                  Contact details
+                </h1>
+              </legend>
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="second-recovery-full-name">
+                  Full name
+                </label>
+                <input class="govuk-input govuk-!-width-three-quarters" id="second-recovery-full-name" name="second-recovery-full-name" type="text" value="{{data['second-recovery-full-name']}}">
+              </div>
+
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="second-recovery-email">
+                  Email address
+                </label>
+                <input class="govuk-input govuk-!-width-one-half" id="second-recovery-email" name="second-recovery-email" type="email" value="{{data['second-recovery-email']}}">
+              </div>
+
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="second-recovery-phone">
+                  Phone number
+                </label>
+                <!-- <div id="contact-hint" class="govuk-hint">
+                   Include the country code for international numbers.
+                </div> -->
+                <input class="govuk-input govuk-input--width-4 govuk-!-margin-right-2" id="second-recovery-phone-code" name="second-recovery-phone-code" type="tel" value="0049{{data['second-recovery-phone-code']}}">
+                <input class="govuk-input govuk-!-width-one-third" id="second-recovery-phone" name="second-recovery-phone" type="tel" value=" {{data['second-recovery-phone']}}">
+              </div>
+
+              <div class="govuk-form-group">
+                <label class="govuk-label" for="second-recovery-fax">
+                  Fax number (optional)
+                </label>
+                <!-- <div id="contact-hint" class="govuk-hint">
+                   Include the country code for international numbers.
+                </div> -->
+                <input class="govuk-input govuk-input--width-4 govuk-!-margin-right-2" id="second-recovery-fax-code" name="second-recovery-fax-code" type="tel" value="0049{{data['second-recovery-fax-code']}}">
+                <input class="govuk-input govuk-!-width-one-third" id="second-recovery-fax" name="second-recovery-fax" type="tel" value="{{data['second-recovery-fax']}}">
+              </div>
+
+              <div class="govuk-!-padding-bottom-2"></div>
+
+
+            </fieldset>
+          </div>
+
+        {{ govukButton({
+          text: 'Save and continue'
+        }) }}
+
+        {% include "./includes/return-to-link.html" %}
+
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -63,6 +63,8 @@
                 <ul class="govuk-list govuk-list--bullet">
                   <li>Iterations to exports<br>
                     - Change return link from task list screens to 'Save and return to draft'<br>
+                    - Example of 'In Progress' tab added to 'Waste codes and description' of task list<br>
+                    - Interim recovery site screens added to Recovery facility section (4) of task list
                   </li>
                   <li>Iterations to templates<br>
                     - Waste carrier journey (details for first to fifth carriers) including details playback screens<br>

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -177,6 +177,40 @@ if ($('#recovery-operation-typeahead-container').length > 0) {
   })
 }
 
+// Part of the Interim site journey
+if ($('#first-recovery-operation-typeahead-container').length > 0) {
+  element = document.querySelector('#first-recovery-operation-typeahead-container')
+  id = 'first-recovery-operation-typeahead' // To match it to the existing <label>.
+
+  accessibleAutocomplete ({
+    element: element,
+    defaultValue: element.getAttribute('data-default-value'),
+    id: id,
+    name: id,
+    source: recoveryOperation,
+    minLength: 1,
+    showAllValues: true,
+    dropdownArrow: () => ''
+  })
+}
+
+// Part of the Interim site journey
+if ($('#second-recovery-operation-typeahead-container').length > 0) {
+  element = document.querySelector('#second-recovery-operation-typeahead-container')
+  id = 'second-recovery-operation-typeahead' // To match it to the existing <label>.
+
+  accessibleAutocomplete ({
+    element: element,
+    defaultValue: element.getAttribute('data-default-value'),
+    id: id,
+    name: id,
+    source: recoveryOperation,
+    minLength: 1,
+    showAllValues: true,
+    dropdownArrow: () => ''
+  })
+}
+
 // D-code autocomplete
 const dCode = [
   'D1: Deposit into or onto land',
@@ -2185,6 +2219,40 @@ if ($('#export-dispatch-typeahead-container').length > 0) {
 if ($('#interim-site-typeahead-container').length > 0) {
   element = document.querySelector('#interim-site-typeahead-container')
   id = 'interim-site-typeahead' // To match it to the existing <label>.
+
+  accessibleAutocomplete ({
+    element: element,
+    defaultValue: element.getAttribute('data-default-value'),
+    id: id,
+    name: id,
+    source: countryList,
+    minLength: 1,
+    showAllValues: true,
+    dropdownArrow: () => ''
+  })
+}
+
+// First recovery autocomplete
+if ($('#first-recovery-typeahead-container').length > 0) {
+  element = document.querySelector('#first-recovery-typeahead-container')
+  id = 'first-recovery-typeahead' // To match it to the existing <label>.
+
+  accessibleAutocomplete ({
+    element: element,
+    defaultValue: element.getAttribute('data-default-value'),
+    id: id,
+    name: id,
+    source: countryList,
+    minLength: 1,
+    showAllValues: true,
+    dropdownArrow: () => ''
+  })
+}
+
+// Second recovery autocomplete
+if ($('#second-recovery-typeahead-container').length > 0) {
+  element = document.querySelector('#second-recovery-typeahead-container')
+  id = 'second-recovery-typeahead' // To match it to the existing <label>.
 
   accessibleAutocomplete ({
     element: element,


### PR DESCRIPTION
Interim sites screens added to export journey
- all screens for the journey added in the Recovery section as per Figma
- content played back for recovery sites (multiple) as per figma
- need to add interim details to the CYA page

Task list
- In Progress tag added to 'waste codes'
- fixed the 'not started' and 'cannot start' tags on Quantity (incorrect ones showing when link was active)